### PR TITLE
fix：修复工作流节点编辑,修改参与者类型保存失败问题

### DIFF
--- a/frontend/src/views/workflow/pages/state.vue
+++ b/frontend/src/views/workflow/pages/state.vue
@@ -87,11 +87,11 @@
               v-for="(label, value) in participant_types"
               :key="value"
               :label="label"
-              :value="parseInt(value)"
+              :value="label"
             ></el-option>
           </el-select>
         </el-form-item>
-        <el-form-item v-if="temp.participant_type == 1" label="参与用户" prop="participant">
+        <el-form-item v-if="temp.participant_type == 'user'" label="参与用户" prop="participant">
           <el-select v-model="temp.user_participant" multiple filterable placeholder="请选择">
             <el-option
               v-for="item in choice_user_list"
@@ -101,7 +101,7 @@
             ></el-option>
           </el-select>
         </el-form-item>
-        <el-form-item v-if="temp.participant_type == 2" label="参与部门" prop="participant">
+        <el-form-item v-if="temp.participant_type == 'group'" label="参与部门" prop="participant">
           <el-select v-model="temp.group_participant" multiple filterable placeholder="请选择">
             <el-option
               v-for="item in choice_group_list"
@@ -111,7 +111,7 @@
             ></el-option>
           </el-select>
         </el-form-item>
-        <el-form-item v-if="temp.participant_type == 3" label="参与角色" prop="participant">
+        <el-form-item v-if="temp.participant_type == 'role'" label="参与角色" prop="participant">
           <el-select v-model="temp.role_participant" multiple filterable placeholder="请选择">
             <el-option
               v-for="item in choice_role_list"
@@ -197,10 +197,10 @@ export default {
         2: "结束状态"
       },
       participant_types: {
-        0: "无处理人",
-        1: "个人",
-        2: "部门",
-        3: "角色"
+        0: "none",
+        1: "user",
+        2: "group",
+        3: "role"
       },
       permprops: {
         key: "id",

--- a/frontend/src/views/workflow/pages/state.vue
+++ b/frontend/src/views/workflow/pages/state.vue
@@ -87,7 +87,7 @@
               v-for="(label, value) in participant_types"
               :key="value"
               :label="label"
-              :value="label"
+              :value="value"
             ></el-option>
           </el-select>
         </el-form-item>
@@ -197,10 +197,10 @@ export default {
         2: "结束状态"
       },
       participant_types: {
-        0: "none",
-        1: "user",
-        2: "group",
-        3: "role"
+        none: "none",
+        user: "用户",
+        group: "部门",
+        role: "角色"
       },
       permprops: {
         key: "id",
@@ -243,7 +243,7 @@ export default {
         order_id: undefined,
         state_type: 0,
         enable_retreat: false,
-        participant_type: 0,
+        participant_type: "none",
         user_participant: [],
         group_participant: [],
         role_participant: [],


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/54677442/123405979-fc754f80-d5dc-11eb-8a09-edf54e1e5368.png)

前端传参是int，不是表模型choice的合法字段，保存失败。
要修改为choice合法的字段